### PR TITLE
DM-44804: Add JSON loading utility and test fixtures (1/3)

### DIFF
--- a/doc/news/DM-44804.feature.rst
+++ b/doc/news/DM-44804.feature.rst
@@ -1,0 +1,1 @@
+Add a ``load_json_data`` utility function and JSON test fixtures for the Zephyr Scale API.

--- a/python/lsst/ts/planning/tool/utils.py
+++ b/python/lsst/ts/planning/tool/utils.py
@@ -18,15 +18,30 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Utility functions for the Zephyr Scale API."""
 
-from .cli import *
-from .utils import *
-from .zephyr_interface import *
+__all__ = ["load_json_data"]
 
-try:
-    from .version import *
-except ImportError:
-    __version__ = "?"
-    __repo_version__ = "?"
-    __fingerprint__ = "? *"
-    __dependency_versions__ = {}
+import json
+import os
+
+
+def load_json_data(filename: str, path: str) -> dict:
+    """
+    Load JSON data from a file.
+
+    Parameters
+    ----------
+    filename : str
+        The name of the file to load.
+    path : str
+        The path to the file.
+
+    Returns
+    -------
+    dict
+        The JSON data.
+    """
+    filepath = os.path.join(path, "data", filename)
+    with open(filepath, "r") as file:
+        return json.load(file)

--- a/tests/data/full_test_case.json
+++ b/tests/data/full_test_case.json
@@ -1,0 +1,163 @@
+{
+    "id": 158630511,
+    "key": "BLOCK-T21",
+    "name": "Test Zephyr Scale interface with Python",
+    "project": {
+        "id": 350001,
+        "self": "https://api.zephyrscale.smartbear.com/v2/projects/350001",
+        "jiraProjectId": 10064,
+        "key": "BLOCK",
+        "enabled": true
+    },
+    "createdOn": "2024-05-17T16:56:13Z",
+    "objective": "Confirm that we can perform multiple operations using Python and Zephyr Scale.",
+    "precondition": null,
+    "estimatedTime": null,
+    "labels": [],
+    "component": null,
+    "priority": {
+        "id": 6360096,
+        "self": "https://api.zephyrscale.smartbear.com/v2/priorities/6360096",
+        "project": {
+            "id": 350001,
+            "self": "https://api.zephyrscale.smartbear.com/v2/projects/350001"
+        },
+        "name": "Normal",
+        "description": null,
+        "index": 2,
+        "color": "#ffa900",
+        "default": false
+    },
+    "status": {
+        "id": 6360092,
+        "self": "https://api.zephyrscale.smartbear.com/v2/statuses/6360092",
+        "project": {
+            "id": 350001,
+            "self": "https://api.zephyrscale.smartbear.com/v2/projects/350001"
+        },
+        "name": "Draft",
+        "description": null,
+        "index": 1,
+        "color": "#f0ad4e",
+        "archived": false,
+        "default": false
+    },
+    "folder": null,
+    "owner": {
+        "self": "https://rubinobs.atlassian.net/rest/api/2/user?accountId=62753116e51c620070bfbcd1",
+        "accountId": "62753116e51c620070bfbcd1",
+        "accountType": "atlassian",
+        "emailAddress": "bquint@lsst.org",
+        "avatarUrls": {
+            "48x48": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/62753116e51c620070bfbcd1/97d29ecf-0dc0-4761-94a6-c240cd1c26b0/48",
+            "24x24": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/62753116e51c620070bfbcd1/97d29ecf-0dc0-4761-94a6-c240cd1c26b0/24",
+            "16x16": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/62753116e51c620070bfbcd1/97d29ecf-0dc0-4761-94a6-c240cd1c26b0/16",
+            "32x32": "https://avatar-management--avatars.us-west-2.prod.public.atl-paas.net/62753116e51c620070bfbcd1/97d29ecf-0dc0-4761-94a6-c240cd1c26b0/32"
+        },
+        "displayName": "Bruno Quint",
+        "active": true,
+        "timeZone": "America/Santiago",
+        "locale": "en_US",
+        "groups": {
+            "size": 7,
+            "items": []
+        },
+        "applicationRoles": {
+            "size": 1,
+            "items": []
+        },
+        "expand": "groups,applicationRoles"
+    },
+    "testScript": {
+        "self": "https://api.zephyrscale.smartbear.com/v2/testcases/BLOCK-T21/teststeps",
+        "next": null,
+        "startAt": 0,
+        "maxResults": 3,
+        "total": 3,
+        "isLast": true,
+        "values": [
+            {
+                "inline": {
+                    "description": "Retrieve the information about test case <strong>BLOCK-T21 (1.0)</strong>",
+                    "testData": "",
+                    "expectedResult": "<br /><br />",
+                    "customFields": {
+                        "SAL Script Configuration": "ignore me",
+                        "External SAL Script?": true,
+                        "SAL Script Name": "do not consider me"
+                    },
+                    "reflectRef": null
+                },
+                "testCase": null
+            },
+            {
+                "inline": {
+                    "description": "Run BLOCK-T74 at elevation \"80\" with the filter \"r_03\"",
+                    "testData": null,
+                    "expectedResult": "BLOCK completes without error. The full BLOCK consists of 27 scripts and should take about 1hr to complete assuming TMA velocity settings of 5%.<br><br><strong>NOTE:&nbsp;</strong>If the \"r0_3\" filter is not installed, please choose the closest filter available.",
+                    "customFields": {
+                        "SAL Script Configuration": "id: BLOCK-T74<br>override:<br>&nbsp; run_elevation: 80<br>&nbsp; run_filter: \"r_03\"",
+                        "External SAL Script?": false,
+                        "SAL Script Name": "maintel/scheduler/add_block.py"
+                    },
+                    "reflectRef": null
+                },
+                "testCase": null
+            },
+            {
+                "inline": {
+                    "description": "Run BLOCK-T74 at elevation \"40\" with the filter \"r_03\"",
+                    "testData": null,
+                    "expectedResult": "BLOCK completes without error. The full BLOCK consists of 27 scripts and should take about 1hr to complete assuming TMA velocity settings of 5%.<br><br><strong>NOTE:&nbsp;</strong>If the \"r0_3\" filter is not installed, please choose the closest filter available.",
+                    "customFields": {
+                        "SAL Script Configuration": "id: BLOCK-T74<br>override:<br>&nbsp; run_elevation: 40<br>&nbsp; run_filter: \"r_03\"",
+                        "External SAL Script?": false,
+                        "SAL Script Name": "maintel/scheduler/add_block.py"
+                    },
+                    "reflectRef": null
+                },
+                "testCase": null
+            },
+            {
+                "inline": {
+                    "description": "Run BLOCK-T74 at elevation \"20\" with the filter \"r_03\"",
+                    "testData": null,
+                    "expectedResult": "BLOCK completes without error. The full BLOCK consists of 27 scripts and should take about 1hr to complete assuming TMA velocity settings of 5%.<br><br><strong>NOTE:&nbsp;</strong>If the \"r0_3\" filter is not installed, please choose the closest filter available.",
+                    "customFields": {
+                        "SAL Script Configuration": "id: BLOCK-T74<br>override:<br>&nbsp; run_elevation: 20<br>&nbsp; run_filter: \"r_03\"",
+                        "External SAL Script?": false,
+                        "SAL Script Name": "maintel/scheduler/add_block.py"
+                    },
+                    "reflectRef": null
+                },
+                "testCase": null
+            },
+            {
+                "inline": {
+                    "description": "Retrieve the information about test cycle <strong>BLOCK-R19</strong>.",
+                    "testData": null,
+                    "expectedResult": "",
+                    "customFields": {
+                        "SAL Script Configuration": "",
+                        "External SAL Script?": false,
+                        "SAL Script Name": ""
+                    },
+                    "reflectRef": null
+                },
+                "testCase": null
+            }
+        ]
+    },
+    "customFields": {
+        "End time available (UTC)": "",
+        "Time Critical": false,
+        "On Sky": false,
+        "Cadency": "",
+        "Start time available (UTC)": ""
+    },
+    "links": {
+        "self": "https://api.zephyrscale.smartbear.com/v2/testcases/BLOCK-T21/links",
+        "issues": [],
+        "webLinks": []
+    }
+}

--- a/tests/data/test_execution_steps.json
+++ b/tests/data/test_execution_steps.json
@@ -1,0 +1,135 @@
+{
+    "next": null,
+    "startAt": 0,
+    "maxResults": 10,
+    "total": 9,
+    "isLast": true,
+    "values": [
+        {
+            "inline": {
+                "description": "<strong>Ensure hexapods compensation mode is disabled</strong><br><br>Before sending both hexapods to their parking position (0 um / 0\u00ba in all axes), we need to power off the compensation mode. Otherwise, they will still have an offset that comes from the compensation mode (look-up tables). Disabling this ensures that al the struts are back to their 0 raw positon.",
+                "testData": null,
+                "expectedResult": "",
+                "actualResult": "",
+                "testDataRowNumber": null,
+                "reflectRef": null,
+                "status": {
+                    "id": 6360081,
+                    "self": "https://api.zephyrscale.smartbear.com/v2/statuses/6360081"
+                }
+            }
+        },
+        {
+            "inline": {
+                "description": "Move MTHexapod:1 (Camera) to origin.",
+                "testData": null,
+                "expectedResult": "Use the <a href=\"https://summit-lsp.lsst.codes/chronograf/sources/1/dashboards/118?refresh=5s&tempVars%5BSalIndex%5D=Camera&tempVars%5Bsampling%5D=High%20Performance&lower=now%28%29%20-%2015m\">Chronograf MTHexapod Dashboard</a> to confirm the movement.",
+                "actualResult": "",
+                "testDataRowNumber": null,
+                "reflectRef": null,
+                "status": {
+                    "id": 6360081,
+                    "self": "https://api.zephyrscale.smartbear.com/v2/statuses/6360081"
+                }
+            }
+        },
+        {
+            "inline": {
+                "description": "Move MTHexapod:2 (M2) to origin.",
+                "testData": null,
+                "expectedResult": "Use the <a href=\"https://summit-lsp.lsst.codes/chronograf/sources/1/dashboards/118?refresh=5s&tempVars%5BSalIndex%5D=Camera&tempVars%5Bsampling%5D=High%20Performance&lower=now%28%29%20-%2015m\">Chronograf MTHexapod Dashboard</a> to confirm the movement.",
+                "actualResult": "",
+                "testDataRowNumber": null,
+                "reflectRef": null,
+                "status": {
+                    "id": 6360081,
+                    "self": "https://api.zephyrscale.smartbear.com/v2/statuses/6360081"
+                }
+            }
+        },
+        {
+            "inline": {
+                "description": "Disable MTHexapod:1 and MTHexapod:2 using ASummaryState in LOVE or via script.",
+                "testData": null,
+                "expectedResult": "MTHexapod.1 and MTHexapod.2 are <strong>DISABLED</strong>.",
+                "actualResult": "",
+                "testDataRowNumber": null,
+                "reflectRef": null,
+                "status": {
+                    "id": 6360081,
+                    "self": "https://api.zephyrscale.smartbear.com/v2/statuses/6360081"
+                }
+            }
+        },
+        {
+            "inline": {
+                "description": "Put MTHexapod:1 and MTHexapod:2 into standby using ASummaryState in LOVE or via script.",
+                "testData": null,
+                "expectedResult": "MTHexapod.1 and MTHexapod.2 are <strong>STANDBY</strong>.",
+                "actualResult": "",
+                "testDataRowNumber": null,
+                "reflectRef": null,
+                "status": {
+                    "id": 6360081,
+                    "self": "https://api.zephyrscale.smartbear.com/v2/statuses/6360081"
+                }
+            }
+        },
+        {
+            "inline": {
+                "description": "Copy log from MTHexapod:1 (camera hexapod) Password in 1password &gt; camera hexapod pxi<br><br>1. Type on the terminal:&nbsp;<br><span spellcheck=\"false\"><strong>scp admin@camhex-pxi-controller.cp.lsst.org:/var/log/messages* .</strong></span><br><br><span spellcheck=\"false\"><strong>2.&nbsp;</strong></span>Compress all files (YYYMMMDD: the obsdate):<br><span spellcheck=\"false\"><strong>tar -czvf camhex_pxi_log_files_YYYYMMDD.tar.gz messages*</strong></span><br><br>3. Put the .gz file on ticket <a href=\"https://rubinobs.atlassian.net/browse/SITCOM-1771\" target=\"_blank\" rel=\"noopener noreferrer\">SITCOM-1771</a>",
+                "testData": null,
+                "expectedResult": "Upload the log from Cam hex pxi to&nbsp;<a href=\"https://rubinobs.atlassian.net/browse/SITCOM-1771\" target=\"_blank\" rel=\"noopener noreferrer\">SITCOM-1771</a>.&nbsp;",
+                "actualResult": "",
+                "testDataRowNumber": null,
+                "reflectRef": null,
+                "status": {
+                    "id": 6360081,
+                    "self": "https://api.zephyrscale.smartbear.com/v2/statuses/6360081"
+                }
+            }
+        },
+        {
+            "inline": {
+                "description": "Copy log from MTHexapod:2. Password in 1password &gt; m2 hexapod pxi<br>1. Type on the terminal:&nbsp;<br><span spellcheck=\"false\"><strong>scp admin@m2hex-pxi-controller.cp.lsst.org:/var/log/messages* .</strong></span><br><br><span spellcheck=\"false\"><strong>2.&nbsp;</strong></span>Compress all files (YYYMMMDD: the obsdate):<br><span spellcheck=\"false\"><strong>tar -czvf camhex_pxi_log_files_YYYYMMDD.tar.gz messages*</strong></span><br><br>3. Put the .gz file on ticket <a href=\"https://rubinobs.atlassian.net/browse/SITCOM-1772\" target=\"_blank\" rel=\"noopener noreferrer\">SITCOM-1772</a>",
+                "testData": null,
+                "expectedResult": "Upload the log from Cam hex pxi to&nbsp;<a href=\"https://rubinobs.atlassian.net/browse/SITCOM-1772\" target=\"_blank\" rel=\"noopener noreferrer\">SITCOM-1772</a>",
+                "actualResult": "",
+                "testDataRowNumber": null,
+                "reflectRef": null,
+                "status": {
+                    "id": 6360081,
+                    "self": "https://api.zephyrscale.smartbear.com/v2/statuses/6360081"
+                }
+            }
+        },
+        {
+            "inline": {
+                "description": "For <em>MTCamHexapod</em>, while in the LSST-WAP, connect to <a href=\"https://tea-pdu01.cp.lsst.org/\" id=\"isPasted\"><em>https://tea-pdu01.cp.lsst.org/</em></a> using the credentials stored in the <em>MainTel Vault</em> of <em>LSST 1Password</em> as&nbsp;<em>PDU Utilities Cabinet</em>. Click on Outlets on the left hand side menu to open the outlets screen.<br>Turn off PXI which is outlet 8, then turn off the drives correspond to outlet 4 in the <em>PDU</em>.",
+                "testData": null,
+                "expectedResult": "<ul><li>CamHexapod's PXI and drives are off.</li></ul>",
+                "actualResult": "",
+                "testDataRowNumber": null,
+                "reflectRef": null,
+                "status": {
+                    "id": 6360081,
+                    "self": "https://api.zephyrscale.smartbear.com/v2/statuses/6360081"
+                }
+            }
+        },
+        {
+            "inline": {
+                "description": "For <em>MTM2Hexapod</em>, while in the LSST-WAP, connect to <a href=\"https://pdu1-tea-as02.cp.lsst.org\"><em>https://pdu1-tea-as02.cp.lsst.org</em></a> using the credentials stored in the <em>MainTel Vault</em> of <em>LSST 1Password</em> as&nbsp;<em>pdu1-tea-as02.cp.lsst.org</em>. Click on Outlets on the left hand side menu to open the outlets screen.<br>Turn off PXI which is outlet 2, then turn off the drives correspond to outlet 1 in the <em>PDU</em>.",
+                "testData": null,
+                "expectedResult": "M2Hexapod's PXI and drives are off.",
+                "actualResult": "",
+                "testDataRowNumber": null,
+                "reflectRef": null,
+                "status": {
+                    "id": 6360081,
+                    "self": "https://api.zephyrscale.smartbear.com/v2/statuses/6360081"
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
**Stacked PR 1 of 3** splitting the stale PR #5 into smaller, reviewable pieces. Targets `develop`.

## What this adds
- `utils.py` with a `load_json_data()` helper for loading JSON fixtures from `tests/data/`.
- Exports `load_json_data` from the package (`__init__.py`), following develop's outside-the-try-block import structure.
- The `full_test_case.json` and `test_execution_steps.json` fixtures used by the Zephyr Scale interface tests.

## Stack (merge bottom-up)
1. **(this PR)** utility-module → `develop`
2. zephyr-interface → utility-module
3. cli → zephyr-interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)